### PR TITLE
feat: add deviceId to RecordingConfig for input device selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,22 @@ if (result.filePath.endsWith(".m4a")) {
 }
 ```
 
-### Device enumeration (desktop only)
+### Device enumeration and selection (desktop only)
 
 ```typescript
 const { devices } = await getDevices(); // returns [] on mobile
 devices.forEach(d => console.log(d.name, d.isDefault ? "(default)" : ""));
+
+// Record from a specific device instead of the system default
+await startRecording({
+  outputPath: "/path/to/recording",
+  deviceId: devices[0].id,
+});
 ```
+
+If the requested device is no longer available when recording starts (e.g.
+unplugged), the recorder logs a warning and falls back to the system default
+device.
 
 ### Max-duration detection
 
@@ -159,6 +169,7 @@ interface RecordingConfig {
   outputPath: string;                   // without extension
   quality?: "low" | "medium" | "high"; // 16kHz mono | 44.1kHz mono | 48kHz stereo
   maxDuration?: number;                 // seconds, 0 = unlimited
+  deviceId?: string;                    // id from getDevices(); desktop only, default = system default
 }
 ```
 

--- a/guest-js/index.ts
+++ b/guest-js/index.ts
@@ -11,6 +11,13 @@ export interface RecordingConfig {
   quality?: AudioQuality;
   /** Maximum recording duration in seconds. 0 means no limit. */
   maxDuration?: number;
+  /**
+   * Input device to record from, identified by the `id` returned from
+   * `getDevices()`. Defaults to the system default input device.
+   * Desktop only; ignored on mobile. Falls back to the default device
+   * if the requested device is no longer available.
+   */
+  deviceId?: string;
 }
 
 export type RecordingState = "idle" | "recording" | "paused";

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -130,6 +130,28 @@ fn recording_thread(rx: mpsc::Receiver<RecorderCommand>, shared: Arc<SharedState
     }
 }
 
+/// Resolve the input device for a recording: the device whose name matches
+/// `device_id` (as returned by `get_devices`), or the system default when no
+/// id is given. A requested device that is no longer present (e.g. unplugged
+/// since the last device scan) falls back to the default so the recording
+/// still succeeds.
+fn find_input_device(host: &cpal::Host, device_id: Option<&str>) -> Result<cpal::Device, Error> {
+    if let Some(id) = device_id {
+        let mut devices = host
+            .input_devices()
+            .map_err(|e| Error::Recording(format!("Failed to enumerate devices: {}", e)))?;
+        if let Some(device) = devices.find(|d| d.name().map(|n| n == id).unwrap_or(false)) {
+            log::info!("Using requested input device: {}", id);
+            return Ok(device);
+        }
+        log::warn!(
+            "Requested input device '{}' not found, falling back to default",
+            id
+        );
+    }
+    host.default_input_device().ok_or(Error::DeviceNotFound)
+}
+
 fn start_recording_internal(
     config: &RecordingConfig,
     shared: &Arc<SharedState>,
@@ -146,7 +168,7 @@ fn start_recording_internal(
     }
 
     let host = cpal::default_host();
-    let device = host.default_input_device().ok_or(Error::DeviceNotFound)?;
+    let device = find_input_device(&host, config.device_id.as_deref())?;
 
     // Get the device's default/supported configuration
     let supported_config = device

--- a/src/models.rs
+++ b/src/models.rs
@@ -54,6 +54,11 @@ pub struct RecordingConfig {
     /// Maximum recording duration in seconds (0 = unlimited)
     #[serde(default)]
     pub max_duration: u32,
+    /// Input device to record from, identified by the `id` returned from
+    /// `get_devices` (default: system default input device).
+    /// Desktop only; ignored on mobile.
+    #[serde(default)]
+    pub device_id: Option<String>,
 }
 
 /// Recording state
@@ -184,5 +189,17 @@ mod tests {
         assert!(matches!(config.format, AudioFormat::Wav));
         assert!(matches!(config.quality, AudioQuality::Medium));
         assert_eq!(config.max_duration, 0);
+        assert_eq!(config.device_id, None);
+    }
+
+    #[test]
+    fn test_recording_config_device_id() {
+        let json = r#"{
+            "outputPath": "/test",
+            "deviceId": "Digta SonicMic 3"
+        }"#;
+        let config: RecordingConfig = serde_json::from_str(json).unwrap();
+
+        assert_eq!(config.device_id.as_deref(), Some("Digta SonicMic 3"));
     }
 }


### PR DESCRIPTION
## What

Adds an optional `deviceId` field to `RecordingConfig` so recording can capture from a specific input device instead of always using the system default.

## Why

`getDevices()` already enumerates all input devices, which invites building a device picker in the UI — but `startRecording` always opened the system default input, so a picker built on it could not actually take effect. (The README listed device selection as planned for a future version.)

## How

- `RecordingConfig.device_id: Option<String>` (`deviceId` in JS), defaulting to `None` = system default, so existing callers are unaffected
- `desktop.rs`: new `find_input_device()` resolves the cpal input device whose name matches the id returned by `get_devices()`; if the requested device is no longer present (e.g. unplugged since the last device scan), it logs a warning and falls back to the default device so the recording still succeeds
- Mobile ignores the field (documented as desktop-only, consistent with `getDevices()`)
- guest-js typings, README docs, and serde round-trip tests included

## Testing

- `cargo test`: all tests pass, incl. new `test_recording_config_device_id` / updated defaults test
- Manually verified in a Tauri 2 app on macOS with three input devices (Bluetooth headset as system default, USB dictation mic, built-in mic): each `deviceId` opens the matching device (confirmed via the distinct negotiated sample rates in `RecordingResult`), and a stale/unknown id falls back to the default without error