### PR TITLE
fix: stop the audio stream explicitly so the input device is released on macOS

### DIFF
--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -113,8 +113,9 @@ fn recording_thread(rx: mpsc::Receiver<RecorderCommand>, shared: Arc<SharedState
                 }
             }
             Ok(RecorderCommand::Shutdown) | Err(_) => {
-                // Clean up and exit
+                // Clean up and exit (pause first — see stop_recording_internal)
                 if let Some(stream) = current_stream.take() {
+                    let _ = stream.pause();
                     drop(stream);
                 }
                 if let Some(writer) = current_writer.take() {
@@ -400,8 +401,15 @@ fn stop_recording_internal(
         return Err(Error::NotRecording);
     }
 
-    // Stop the stream
+    // Stop the stream. Dropping alone is not enough: on macOS (cpal 0.15)
+    // the stream's device-disconnect listener holds a clone of the stream,
+    // so this drop never destroys the AudioUnit and the input device stays
+    // open — the OS mic-in-use indicator (and e.g. the record LED on USB
+    // dictation microphones) stays on for the app's lifetime.
     if let Some(s) = stream.take() {
+        if let Err(e) = s.pause() {
+            log::warn!("Failed to stop audio stream: {}", e);
+        }
         drop(s);
     }
 


### PR DESCRIPTION
## Problem

On macOS, stopping a recording never actually releases the input device. The OS mic-in-use indicator (orange dot) stays on for the app's lifetime, USB mics with a hardware record LED keep it lit, and `kAudioDevicePropertyDeviceIsRunningSomewhere` stays `1` on the device after `stop_recording`.

## Root cause

`stop_recording_internal` relies on dropping the `cpal::Stream` to end capture. On the coreaudio backend (cpal 0.15) that drop is not enough: `cpal::Stream` is `Arc<Mutex<StreamInner>>`, and the device-disconnect listener registered in `build_input_stream` holds a **clone of the stream inside the stream's own inner** (`add_disconnect_listener` in cpal's `host/coreaudio/macos/mod.rs`) — an Arc reference cycle. The refcount never reaches zero, `StreamInner` is never dropped, and the running `AudioUnit` is never stopped or disposed. Every recording leaks one running capture unit.

Observable side effects besides the stuck indicator: `SharedState::duration_ms` keeps being overwritten by the leaked streams' callbacks, so `get_status` can report bogus durations from ghost streams.

## Fix

Call `pause()` (→ `AudioOutputUnitStop`) on the stream before dropping it, in both the stop path and the shutdown path. Capture then ends deterministically regardless of whether the drop frees the object.

## Verified

macOS 15 (arm64): after `stop_recording`, `kAudioDevicePropertyDeviceIsRunningSomewhere` returns `0` (was `1` before the fix), mic-in-use indicator clears, repeated record/stop cycles work, and `durationMs` in the stop result is exact (no more ghost-callback corruption).