### PR TITLE
Allow record channel selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Granular:
     "audio-recorder:allow-resume-recording",
     "audio-recorder:allow-get-status",
     "audio-recorder:allow-get-devices",
+    "audio-recorder:allow-get-channels",
     "audio-recorder:allow-check-permission",
     "audio-recorder:allow-request-permission"
   ]
@@ -86,6 +87,7 @@ import {
   resumeRecording,
   getStatus,
   getDevices,
+  getChannels,
   requestPermission,
 } from "tauri-plugin-audio-recorder-api";
 
@@ -135,6 +137,25 @@ If the requested device is no longer available when recording starts (e.g.
 unplugged), the recorder logs a warning and falls back to the system default
 device.
 
+### Channel selection (desktop only)
+
+By default every channel the device provides is recorded. To capture a single
+channel of a multi-channel input, pick one from `getChannels()`:
+
+```typescript
+const { channels } = await getChannels(devices[0].id); // omit the id for the default device
+channels.forEach(c => console.log(c.id, c.name)); // "0" "Channel 1", "1" "Channel 2", …
+
+await startRecording({
+  outputPath: "/path/to/recording",
+  deviceId: devices[0].id,
+  channelId: channels[1].id, // mono recording of Channel 2
+});
+```
+
+Unlike `deviceId`, an invalid `channelId` does not fall back — `startRecording()`
+throws `Invalid channel: …` and nothing is recorded.
+
 ### Max-duration detection
 
 `maxDuration` stops recording automatically with no callback. Poll to detect completion — and do **not** call `stopRecording()` afterward, since the recorder is already idle:
@@ -160,6 +181,7 @@ const poll = setInterval(async () => {
 - `resumeRecording()`
 - `getStatus()` → `{ state, durationMs, outputPath }`
 - `getDevices()` → `{ devices }` — desktop only, empty on mobile
+- `getChannels(deviceId?)` → `{ channels }` — desktop only, empty on mobile
 - `checkPermission()` / `requestPermission()` → `{ granted, canRequest }`
 
 ### RecordingConfig
@@ -170,6 +192,7 @@ interface RecordingConfig {
   quality?: "low" | "medium" | "high"; // 16kHz mono | 44.1kHz mono | 48kHz stereo
   maxDuration?: number;                 // seconds, 0 = unlimited
   deviceId?: string;                    // id from getDevices(); desktop only, default = system default
+  channelId?: string;                   // id from getChannels(); desktop only, default = all channels
 }
 ```
 

--- a/build.rs
+++ b/build.rs
@@ -5,6 +5,7 @@ const COMMANDS: &[&str] = &[
     "resume_recording",
     "get_status",
     "get_devices",
+    "get_channels",
     "check_permission",
     "request_permission",
 ];

--- a/guest-js/index.ts
+++ b/guest-js/index.ts
@@ -18,6 +18,14 @@ export interface RecordingConfig {
    * if the requested device is no longer available.
    */
   deviceId?: string;
+  /**
+   * Input channel to record from, identified by the `id` returned from
+   * `getChannels()`. Defaults to all channels of the device; selecting a
+   * channel produces a mono recording.
+   * Desktop only; ignored on mobile. Throws if the device does not have
+   * the requested channel.
+   */
+  channelId?: string;
 }
 
 export type RecordingState = "idle" | "recording" | "paused";
@@ -52,6 +60,16 @@ export interface AudioDevice {
 
 export interface DevicesResponse {
   devices: AudioDevice[];
+}
+
+export interface AudioChannel {
+  id: string;
+  name: string;
+  isDefault: boolean;
+}
+
+export interface ChannelsResponse {
+  channels: AudioChannel[];
 }
 
 export async function startRecording(config: RecordingConfig): Promise<void> {
@@ -97,4 +115,15 @@ export async function requestPermission(): Promise<PermissionResponse> {
  */
 export async function getDevices(): Promise<DevicesResponse> {
   return await invoke("plugin:audio-recorder|get_devices");
+}
+
+/**
+ * Get the input channels of an audio device.
+ * @param deviceId Device to inspect, from `getDevices()`. Defaults to the system default input device.
+ * @returns List of available channels
+ */
+export async function getChannels(
+  deviceId?: string,
+): Promise<ChannelsResponse> {
+  return await invoke("plugin:audio-recorder|get_channels", { deviceId });
 }

--- a/permissions/autogenerated/commands/get_channels.toml
+++ b/permissions/autogenerated/commands/get_channels.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-get-channels"
+description = "Enables the get_channels command without any pre-configured scope."
+commands.allow = ["get_channels"]
+
+[[permission]]
+identifier = "deny-get-channels"
+description = "Denies the get_channels command without any pre-configured scope."
+commands.deny = ["get_channels"]

--- a/permissions/autogenerated/reference.md
+++ b/permissions/autogenerated/reference.md
@@ -10,6 +10,7 @@ Default permissions for the Audio Recorder plugin - allows all audio recording o
 - `allow-resume-recording`
 - `allow-get-status`
 - `allow-get-devices`
+- `allow-get-channels`
 - `allow-check-permission`
 - `allow-request-permission`
 
@@ -44,6 +45,32 @@ Enables the check_permission command without any pre-configured scope.
 <td>
 
 Denies the check_permission command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`audio-recorder:allow-get-channels`
+
+</td>
+<td>
+
+Enables the get_channels command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`audio-recorder:deny-get-channels`
+
+</td>
+<td>
+
+Denies the get_channels command without any pre-configured scope.
 
 </td>
 </tr>

--- a/permissions/default.toml
+++ b/permissions/default.toml
@@ -9,6 +9,7 @@ permissions = [
     "allow-resume-recording",
     "allow-get-status",
     "allow-get-devices",
+    "allow-get-channels",
     "allow-check-permission",
     "allow-request-permission",
 ]

--- a/permissions/schemas/schema.json
+++ b/permissions/schemas/schema.json
@@ -307,6 +307,18 @@
           "markdownDescription": "Denies the check_permission command without any pre-configured scope."
         },
         {
+          "description": "Enables the get_channels command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-channels",
+          "markdownDescription": "Enables the get_channels command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_channels command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-channels",
+          "markdownDescription": "Denies the get_channels command without any pre-configured scope."
+        },
+        {
           "description": "Enables the get_devices command without any pre-configured scope.",
           "type": "string",
           "const": "allow-get-devices",
@@ -391,10 +403,10 @@
           "markdownDescription": "Denies the stop_recording command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the Audio Recorder plugin - allows all audio recording operations\n#### This default permission set includes:\n\n- `allow-start-recording`\n- `allow-stop-recording`\n- `allow-pause-recording`\n- `allow-resume-recording`\n- `allow-get-status`\n- `allow-get-devices`\n- `allow-check-permission`\n- `allow-request-permission`",
+          "description": "Default permissions for the Audio Recorder plugin - allows all audio recording operations\n#### This default permission set includes:\n\n- `allow-start-recording`\n- `allow-stop-recording`\n- `allow-pause-recording`\n- `allow-resume-recording`\n- `allow-get-status`\n- `allow-get-devices`\n- `allow-get-channels`\n- `allow-check-permission`\n- `allow-request-permission`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the Audio Recorder plugin - allows all audio recording operations\n#### This default permission set includes:\n\n- `allow-start-recording`\n- `allow-stop-recording`\n- `allow-pause-recording`\n- `allow-resume-recording`\n- `allow-get-status`\n- `allow-get-devices`\n- `allow-check-permission`\n- `allow-request-permission`"
+          "markdownDescription": "Default permissions for the Audio Recorder plugin - allows all audio recording operations\n#### This default permission set includes:\n\n- `allow-start-recording`\n- `allow-stop-recording`\n- `allow-pause-recording`\n- `allow-resume-recording`\n- `allow-get-status`\n- `allow-get-devices`\n- `allow-get-channels`\n- `allow-check-permission`\n- `allow-request-permission`"
         }
       ]
     }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -43,6 +43,15 @@ pub(crate) async fn get_devices<R: Runtime>(app: AppHandle<R>) -> Result<AudioDe
     app.audio_recorder().get_devices()
 }
 
+/// List the input channels of an audio device
+#[command]
+pub(crate) async fn get_channels<R: Runtime>(
+    app: AppHandle<R>,
+    device_id: Option<String>,
+) -> Result<AudioChannelsResponse> {
+    app.audio_recorder().get_channels(device_id)
+}
+
 /// Check microphone permission status
 #[command]
 pub(crate) async fn check_permission<R: Runtime>(app: AppHandle<R>) -> Result<PermissionStatus> {

--- a/src/desktop.rs
+++ b/src/desktop.rs
@@ -153,6 +153,58 @@ fn find_input_device(host: &cpal::Host, device_id: Option<&str>) -> Result<cpal:
     host.default_input_device().ok_or(Error::DeviceNotFound)
 }
 
+/// Number of input channels a device can deliver: the widest configuration it
+/// supports, since that is the stream a single channel has to be picked out of.
+fn device_channel_count(device: &cpal::Device) -> u16 {
+    let from_supported = device
+        .supported_input_configs()
+        .ok()
+        .and_then(|configs| configs.map(|cfg| cfg.channels()).max());
+
+    match from_supported {
+        Some(channels) if channels > 0 => channels,
+        _ => device
+            .default_input_config()
+            .map(|cfg| cfg.channels())
+            .unwrap_or(1),
+    }
+}
+
+/// Resolve the channel index for a recording: the channel whose `id` (as
+/// returned by `get_channels`) was requested, or `None` to record every
+/// channel. Unlike a missing device, a channel the device does not have is an
+/// error — silently recording a different channel would be indistinguishable
+/// from success.
+fn resolve_channel(channel_id: Option<&str>, available: u16) -> Result<Option<u16>, Error> {
+    let Some(id) = channel_id else {
+        return Ok(None);
+    };
+
+    let index: u16 = id
+        .parse()
+        .map_err(|_| Error::InvalidChannel(format!("'{}' is not a channel id", id)))?;
+
+    if index >= available {
+        return Err(Error::InvalidChannel(format!(
+            "'{}' — device has {} channel(s)",
+            id, available
+        )));
+    }
+
+    log::info!("Using requested input channel: {}", index);
+    Ok(Some(index))
+}
+
+/// Samples that belong in the WAV file: the whole interleaved buffer, or only
+/// the selected channel's sample from each frame.
+fn wav_samples<T>(data: &[T], channel: Option<u16>, channels: u16) -> impl Iterator<Item = &T> {
+    let (offset, step) = match channel {
+        Some(index) => (index as usize, channels as usize),
+        None => (0, 1),
+    };
+    data.iter().skip(offset).step_by(step)
+}
+
 fn start_recording_internal(
     config: &RecordingConfig,
     shared: &Arc<SharedState>,
@@ -170,6 +222,8 @@ fn start_recording_internal(
 
     let host = cpal::default_host();
     let device = find_input_device(&host, config.device_id.as_deref())?;
+    let available_channels = device_channel_count(&device);
+    let selected_channel = resolve_channel(config.channel_id.as_deref(), available_channels)?;
 
     // Get the device's default/supported configuration
     let supported_config = device
@@ -178,7 +232,12 @@ fn start_recording_internal(
 
     // Try to use quality preset settings, fall back to device defaults
     let target_sample_rate = config.quality.sample_rate();
-    let target_channels = config.quality.channels();
+    let target_channels = match selected_channel {
+        // A single channel can only be picked out of a stream that carries it,
+        // so capture everything the device offers and drop the rest on write.
+        Some(_) => available_channels,
+        None => config.quality.channels(),
+    };
 
     // Check if device supports the target configuration
     let supported_configs = device.supported_input_configs();
@@ -233,6 +292,24 @@ fn start_recording_internal(
         )
     };
 
+    // The negotiation above can settle on fewer channels than the device
+    // advertises, which would leave the requested channel out of the stream.
+    if let Some(index) = selected_channel {
+        if index >= channels {
+            return Err(Error::InvalidChannel(format!(
+                "'{}' — the input stream has {} channel(s)",
+                index, channels
+            )));
+        }
+    }
+
+    // Only the selected channel is written, so the file becomes mono
+    let output_channels = if selected_channel.is_some() {
+        1
+    } else {
+        channels
+    };
+
     log::info!(
         "Recording config: {}Hz, {} channels, format: {:?}",
         sample_rate,
@@ -276,7 +353,7 @@ fn start_recording_internal(
     }
 
     let spec = WavSpec {
-        channels,
+        channels: output_channels,
         sample_rate,
         bits_per_sample: 16,
         sample_format: hound::SampleFormat::Int,
@@ -304,7 +381,7 @@ fn start_recording_internal(
                 }
                 if let Ok(mut guard) = writer_clone.lock() {
                     if let Some(ref mut w) = *guard {
-                        for &sample in data {
+                        for &sample in wav_samples(data, selected_channel, channels) {
                             let sample_i16 = (sample * 32767.0) as i16;
                             let _ = w.write_sample(sample_i16);
                         }
@@ -328,7 +405,7 @@ fn start_recording_internal(
                     }
                     if let Ok(mut guard) = writer_clone.lock() {
                         if let Some(ref mut w) = *guard {
-                            for &sample in data {
+                            for &sample in wav_samples(data, selected_channel, channels) {
                                 let _ = w.write_sample(sample);
                             }
                         }
@@ -352,7 +429,7 @@ fn start_recording_internal(
                     }
                     if let Ok(mut guard) = writer_clone.lock() {
                         if let Some(ref mut w) = *guard {
-                            for &sample in data {
+                            for &sample in wav_samples(data, selected_channel, channels) {
                                 let sample_i16 = (sample as i32 - 32768) as i16;
                                 let _ = w.write_sample(sample_i16);
                             }
@@ -380,13 +457,15 @@ fn start_recording_internal(
     shared
         .sample_rate
         .store(sample_rate as u64, Ordering::SeqCst);
-    shared.channels.store(channels as u64, Ordering::SeqCst);
+    shared
+        .channels
+        .store(output_channels as u64, Ordering::SeqCst);
     *shared.output_path.lock().unwrap() = Some(file_path);
 
     log::info!(
         "Recording started: {}Hz, {} channels",
         sample_rate,
-        channels
+        output_channels
     );
 
     Ok((stream, writer, write_enabled))
@@ -560,6 +639,22 @@ impl<R: Runtime> AudioRecorder<R> {
         Ok(AudioDevicesResponse { devices: result })
     }
 
+    /// List the input channels of an audio device
+    pub fn get_channels(&self, device_id: Option<String>) -> crate::Result<AudioChannelsResponse> {
+        let host = cpal::default_host();
+        let device = find_input_device(&host, device_id.as_deref())?;
+
+        let channels = (0..device_channel_count(&device))
+            .map(|index| AudioChannel {
+                id: index.to_string(),
+                name: format!("Channel {}", index + 1),
+                is_default: index == 0,
+            })
+            .collect();
+
+        Ok(AudioChannelsResponse { channels })
+    }
+
     /// Check microphone permission (always granted on desktop)
     pub fn check_permission(&self) -> crate::Result<PermissionStatus> {
         // On desktop, microphone access is typically granted at the OS level
@@ -589,5 +684,50 @@ impl<R: Runtime> Drop for AudioRecorder<R> {
                 let _ = handle.join();
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_channel_none() {
+        assert_eq!(resolve_channel(None, 2).unwrap(), None);
+    }
+
+    #[test]
+    fn test_resolve_channel_selected() {
+        assert_eq!(resolve_channel(Some("0"), 2).unwrap(), Some(0));
+        assert_eq!(resolve_channel(Some("1"), 2).unwrap(), Some(1));
+    }
+
+    #[test]
+    fn test_resolve_channel_invalid() {
+        assert!(matches!(
+            resolve_channel(Some("2"), 2),
+            Err(Error::InvalidChannel(_))
+        ));
+        assert!(matches!(
+            resolve_channel(Some("abc"), 2),
+            Err(Error::InvalidChannel(_))
+        ));
+    }
+
+    #[test]
+    fn test_wav_samples_all_channels() {
+        let data = [1, 2, 3, 4];
+        let samples: Vec<_> = wav_samples(&data, None, 2).copied().collect();
+        assert_eq!(samples, vec![1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn test_wav_samples_selected_channel() {
+        // Two interleaved frames: [left, right, left, right]
+        let data = [1, 2, 3, 4];
+        let left: Vec<_> = wav_samples(&data, Some(0), 2).copied().collect();
+        let right: Vec<_> = wav_samples(&data, Some(1), 2).copied().collect();
+        assert_eq!(left, vec![1, 3]);
+        assert_eq!(right, vec![2, 4]);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -22,6 +22,9 @@ pub enum Error {
     #[error("Audio device not found")]
     DeviceNotFound,
 
+    #[error("Invalid channel: {0}")]
+    InvalidChannel(String),
+
     #[error("Unsupported audio format")]
     UnsupportedFormat,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,7 @@ pub fn init<R: Runtime>() -> TauriPlugin<R> {
             commands::resume_recording,
             commands::get_status,
             commands::get_devices,
+            commands::get_channels,
             commands::check_permission,
             commands::request_permission,
         ])

--- a/src/mobile.rs
+++ b/src/mobile.rs
@@ -67,6 +67,12 @@ impl<R: Runtime> AudioRecorder<R> {
             .map_err(Into::into)
     }
 
+    /// List the input channels of an audio device
+    pub fn get_channels(&self, _device_id: Option<String>) -> crate::Result<AudioChannelsResponse> {
+        // Mobile records the active audio route; channel selection is desktop only
+        Ok(AudioChannelsResponse { channels: vec![] })
+    }
+
     /// Check microphone permission
     pub fn check_permission(&self) -> crate::Result<PermissionStatus> {
         self.0

--- a/src/models.rs
+++ b/src/models.rs
@@ -59,6 +59,12 @@ pub struct RecordingConfig {
     /// Desktop only; ignored on mobile.
     #[serde(default)]
     pub device_id: Option<String>,
+    /// Input channel to record from, identified by the `id` returned from
+    /// `get_channels` (default: all channels of the device).
+    /// Selecting a channel produces a mono recording.
+    /// Desktop only; ignored on mobile.
+    #[serde(default)]
+    pub channel_id: Option<String>,
 }
 
 /// Recording state
@@ -121,6 +127,25 @@ pub struct AudioDevice {
 #[serde(rename_all = "camelCase")]
 pub struct AudioDevicesResponse {
     pub devices: Vec<AudioDevice>,
+}
+
+/// Audio input channel of a device
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioChannel {
+    /// Channel identifier (the channel's index in the input stream)
+    pub id: String,
+    /// Human-readable channel name
+    pub name: String,
+    /// Whether this is the first channel of the device
+    pub is_default: bool,
+}
+
+/// List of available channels of an audio device
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioChannelsResponse {
+    pub channels: Vec<AudioChannel>,
 }
 
 /// Permission status
@@ -190,6 +215,7 @@ mod tests {
         assert!(matches!(config.quality, AudioQuality::Medium));
         assert_eq!(config.max_duration, 0);
         assert_eq!(config.device_id, None);
+        assert_eq!(config.channel_id, None);
     }
 
     #[test]
@@ -201,5 +227,16 @@ mod tests {
         let config: RecordingConfig = serde_json::from_str(json).unwrap();
 
         assert_eq!(config.device_id.as_deref(), Some("Digta SonicMic 3"));
+    }
+
+    #[test]
+    fn test_recording_config_channel_id() {
+        let json = r#"{
+            "outputPath": "/test",
+            "channelId": "1"
+        }"#;
+        let config: RecordingConfig = serde_json::from_str(json).unwrap();
+
+        assert_eq!(config.channel_id.as_deref(), Some("1"));
     }
 }


### PR DESCRIPTION
By default every channel the device provides is recorded. With these changes it is possible to capture a single
channel of a multi-channel input. You canpick one from `getChannels()`:

```typescript
const { channels } = await getChannels(devices[0].id); // omit the id for the default device
channels.forEach(c => console.log(c.id, c.name)); // "0" "Channel 1", "1" "Channel 2", …

await startRecording({
  outputPath: "/path/to/recording",
  deviceId: devices[0].id,
  channelId: channels[1].id, // mono recording of Channel 2
});
```

The default behaviour is unchanged.